### PR TITLE
Replace has_git by test_requires_git

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,5 +1,6 @@
 requires 'perl', '5.008001';
 requires 'Git::Repository', '1.14';
+requires 'Test::Requires::Git', '1.005';
 
 on 'test' => sub {
     requires 'Test::More', '0.98';

--- a/t/install_hook.t
+++ b/t/install_hook.t
@@ -3,12 +3,13 @@ use warnings;
 
 use File::Temp qw();
 
-use Test::Git qw(has_git test_repository);
+use Test::Git qw(test_repository);
+use Test::Requires::Git;
 use Git::Repository qw(Hooks);
 
 use Test::More;
 
-has_git();
+test_requires_git();
 plan tests => 3;
 
 my $repo = test_repository();


### PR DESCRIPTION
Test::Git::has_git is obsolete and replaced by
Test::Requires::Git::test_requires_git.
